### PR TITLE
fix: linter on Atom

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,11 @@
     "react-scripts": "0.4.1"
   },
   "dependencies": {
+    "babel-eslint": "^6.1.2",
+    "eslint": "^3.5.0",
+    "eslint-plugin-flowtype": "^2.18.1",
+    "eslint-plugin-jsx-a11y": "^2.2.2",
+    "eslint-plugin-react": "^6.2.2",
     "material-ui": "^0.15.4",
     "react": "^15.3.1",
     "react-dom": "^15.3.1",


### PR DESCRIPTION
Linter packages are not loaded automatically on Atom.
following packages are added
-    "babel-eslint": "^6.1.2",
-    "eslint": "^3.5.0",
-    "eslint-plugin-flowtype": "^2.18.1",
-    "eslint-plugin-jsx-a11y": "^2.2.2",
-    "eslint-plugin-react": "^6.2.2"
